### PR TITLE
fix: build latest tag only on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ stages:
 
           - script: docker-compose run tests
             displayName: 'Run Tests'
-            enabled: false
             env:
               CPU_COUNT: $(CPU_COUNT)
               LEGACY_OAUTH_API_URL: $(LEGACY_OAUTH_API_URL)


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-1582

Tag latest se pushuje do test repository jen pri master buildu, takze odpovida produkcni verzi. Tagovanej image se tam pushuje vzdycky, takze v pripade potreby se da pouzit `keboola.azurecr.io/job-queue-internal-api:1234`.
Navic to vyprodukuje artefact ve kterym je produkcni tag a to se pak pouzije v https://github.com/keboola/job-queue-daemon/pull/83
