### PR TITLE
feat: apply cleanup only on terminating jobs

### DIFF
--- a/.env
+++ b/.env
@@ -8,3 +8,4 @@ APP_SECRET=a1956d4d5d173273db7d638ed5b50ca0
 ###< symfony/framework-bundle ###
 
 legacy_encryption_key=1234567890abcdef
+JOB_QUEUE_TOKEN=sampleToken

--- a/provisioning/dev/internal-api.yaml
+++ b/provisioning/dev/internal-api.yaml
@@ -103,6 +103,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
+  namespace: dev-job-runner
   labels:
     app: dev-job-queue-internal-api
   name: dev-job-queue-internal-api

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\LogInfo;
 use Keboola\ErrorControl\Monolog\LogProcessor;
 use Keboola\JobQueueInternalClient\Client as QueueClient;
+use Keboola\JobQueueInternalClient\Exception\ClientException;
 use Keboola\JobQueueInternalClient\JobFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -45,9 +46,15 @@ class CleanupCommand extends Command
             return 0;
         }
         $this->logProcessor->setLogInfo(new LogInfo($jobId, '', ''));
-        $jobStatus = $this->queueClient->getJob($jobId)->getStatus();
-        if ($jobStatus !== JobFactory::STATUS_TERMINATING) {
-            $this->logger->info(sprintf('Job "%s" is in status "%s", letting the job to finish.', $jobId, $jobStatus));
+        try {
+            $jobStatus = $this->queueClient->getJob($jobId)->getStatus();
+            if ($jobStatus !== JobFactory::STATUS_TERMINATING) {
+                $this->logger->info(sprintf('Job "%s" is in status "%s", letting the job to finish.', $jobId, $jobStatus));
+                return 0;
+            }
+        } catch (ClientException $e) {
+            $this->logger->error(sprintf('Failed to get job "%s" for cleanup: ' . $e->getMessage(), $jobId));
+            // we don't want the preStop hook to crash
             return 0;
         }
         $this->logger->info(sprintf('Terminating containers for job "%s".', $jobId));

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -49,7 +49,9 @@ class CleanupCommand extends Command
         try {
             $jobStatus = $this->queueClient->getJob($jobId)->getStatus();
             if ($jobStatus !== JobFactory::STATUS_TERMINATING) {
-                $this->logger->info(sprintf('Job "%s" is in status "%s", letting the job to finish.', $jobId, $jobStatus));
+                $this->logger->info(
+                    sprintf('Job "%s" is in status "%s", letting the job to finish.', $jobId, $jobStatus)
+                );
                 return 0;
             }
         } catch (ClientException $e) {

--- a/tests/Command/AbstractCommandTest.php
+++ b/tests/Command/AbstractCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use Keboola\JobQueueInternalClient\Client;
+use Keboola\JobQueueInternalClient\JobFactory;
+use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class AbstractCommandTest extends KernelTestCase
+{
+    /**
+     * @return array{factory: JobFactory, client: Client}
+     */
+    protected function getJobFactoryAndClient(): array
+    {
+        $storageClientFactory = new JobFactory\StorageClientFactory((string) getenv('STORAGE_API_URL'));
+        $objectEncryptor = new ObjectEncryptorFactory(
+            (string) getenv('AWS_KMS_KEY'),
+            (string) getenv('AWS_REGION'),
+            '',
+            '',
+            (string) getenv('AZURE_KEY_VAULT_URL'),
+        );
+        $jobFactory = new JobFactory($storageClientFactory, $objectEncryptor);
+        $client = new Client(
+            new NullLogger(),
+            $jobFactory,
+            (string) getenv('JOB_QUEUE_URL'),
+            (string) getenv('JOB_QUEUE_TOKEN')
+        );
+        return ['factory' => $jobFactory, 'client' => $client];
+    }
+}

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -4,18 +4,38 @@ declare(strict_types=1);
 
 namespace App\Tests\Command;
 
+use Keboola\JobQueueInternalClient\JobFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use ReflectionProperty;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Process\Process;
 
-class CleanupCommandTest extends KernelTestCase
+class CleanupCommandTest extends AbstractCommandTest
 {
-    public function testExecuteSuccess(): void
+    public function testExecuteSuccessTerminatingJob(): void
     {
+        $storageClientFactory = new JobFactory\StorageClientFactory((string) getenv('STORAGE_API_URL'));
+        $storageClient = $storageClientFactory->getClient((string) getenv('TEST_STORAGE_API_TOKEN'));
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
+        $tokenInfo = $storageClient->verifytoken();
+        $id = $storageClient->generateId();
+        $job = $jobFactory->loadFromExistingJobData([
+            'id' => $id,
+            'runId' => $id,
+            'componentId' => 'keboola.runner-config-test',
+            'projectId' => $tokenInfo['owner']['id'],
+            'projectName' => $tokenInfo['owner']['name'],
+            'tokenDescription' => $tokenInfo['description'],
+            'tokenId' => $tokenInfo['id'],
+            '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'status' => JobFactory::STATUS_TERMINATING,
+            'desiredStatus' => JobFactory::DESIRED_STATUS_TERMINATING,
+            'mode' => 'run',
+            'configId' => 'dummy',
+        ]);
+        $job = $client->createJob($job);
         $kernel = static::createKernel();
         $application = new Application($kernel);
         $command = $application->find('app:cleanup');
@@ -28,15 +48,15 @@ class CleanupCommandTest extends KernelTestCase
 
         $commandText = 'docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=30 ' .
             '--label com.keboola.docker-runner.jobId=%s waisbrot/wait';
-        $process = Process::fromShellCommandline(sprintf($commandText, 1234));
+        $process = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
         $process->setTimeout(600); // to pull the image if necessary
         $process->mustRun();
-        $process = Process::fromShellCommandline(sprintf($commandText, 1234));
+        $process = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
         $process->mustRun();
         $process = Process::fromShellCommandline(sprintf($commandText, 4321));
         $process->mustRun();
         $process = Process::fromShellCommandline(
-            'docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=1234"'
+            sprintf('docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"', $job->getId())
         );
         $process->mustRun();
         $toRemove = explode("\n", trim($process->getOutput()));
@@ -46,14 +66,18 @@ class CleanupCommandTest extends KernelTestCase
         $process->mustRun();
         $toKeep = explode("\n", trim($process->getOutput()));
 
-        putenv('JOB_ID=1234');
+        putenv('JOB_ID=' . $job->getId());
         $commandTester = new CommandTester($command);
         $ret = $commandTester->execute([
             'command' => $command->getName(),
         ]);
-        self::assertTrue($testHandler->hasInfoThatContains('Terminating containers for job "1234"'));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            sprintf('Terminating containers for job "%s"', $job->getId())
+        ));
         self::assertTrue($testHandler->hasInfoThatContains('Terminating container'));
-        self::assertTrue($testHandler->hasInfoThatContains('Finished container cleanup for job "1234"'));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            sprintf('Finished container cleanup for job "%s"', $job->getId())
+        ));
         self::assertEquals(0, $ret);
         $process = Process::fromShellCommandline('docker ps --format "{{.ID}}"');
         $process->mustRun();
@@ -63,6 +87,91 @@ class CleanupCommandTest extends KernelTestCase
         foreach ($toRemove as $containerId) {
             self::assertNotContains($containerId, $containers);
         }
+        putenv('JOB_ID=');
+    }
+
+    public function testExecuteSuccessNonTerminatingJob(): void
+    {
+        $storageClientFactory = new JobFactory\StorageClientFactory((string) getenv('STORAGE_API_URL'));
+        $storageClient = $storageClientFactory->getClient((string) getenv('TEST_STORAGE_API_TOKEN'));
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
+        $tokenInfo = $storageClient->verifytoken();
+        $id = $storageClient->generateId();
+        $job = $jobFactory->loadFromExistingJobData([
+            'id' => $id,
+            'runId' => $id,
+            'componentId' => 'keboola.runner-config-test',
+            'projectId' => $tokenInfo['owner']['id'],
+            'projectName' => $tokenInfo['owner']['name'],
+            'tokenDescription' => $tokenInfo['description'],
+            'tokenId' => $tokenInfo['id'],
+            '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'status' => JobFactory::STATUS_PROCESSING,
+            'desiredStatus' => JobFactory::DESIRED_STATUS_PROCESSING,
+            'mode' => 'run',
+            'configId' => 'dummy',
+            'configData' => [
+                'parameters' => [
+                    'operation' => 'unsafe-dump-config',
+                    'arbitrary' => [
+                        '#foo' => 'bar',
+                    ],
+                ],
+            ],
+        ]);
+        $job = $client->createJob($job);
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+        $command = $application->find('app:cleanup');
+        $property = new ReflectionProperty($command, 'logger');
+        $property->setAccessible(true);
+        /** @var Logger $logger */
+        $logger = $property->getValue($command);
+        $testHandler = new TestHandler();
+        $logger->pushHandler($testHandler);
+
+        $commandText = 'docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=30 ' .
+            '--label com.keboola.docker-runner.jobId=%s waisbrot/wait';
+        $process = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
+        $process->setTimeout(600); // to pull the image if necessary
+        $process->mustRun();
+        $process = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
+        $process->mustRun();
+        $process = Process::fromShellCommandline(sprintf($commandText, 4321));
+        $process->mustRun();
+        $process = Process::fromShellCommandline(
+            sprintf('docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"', $job->getId())
+        );
+        $process->mustRun();
+        $jobContainers = explode("\n", trim($process->getOutput()));
+        $process = Process::fromShellCommandline(
+            'docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=4321"'
+        );
+        $process->mustRun();
+        $nonJobContainers = explode("\n", trim($process->getOutput()));
+
+        putenv('JOB_ID=' . $job->getId());
+        $commandTester = new CommandTester($command);
+        $ret = $commandTester->execute([
+            'command' => $command->getName(),
+        ]);
+        self::assertFalse($testHandler->hasInfoThatContains(
+            sprintf('Terminating containers for job "%s"', $job->getId())
+        ));
+        self::assertFalse($testHandler->hasInfoThatContains('Terminating container'));
+        self::assertFalse($testHandler->hasInfoThatContains(
+            sprintf('Finished container cleanup for job "%s"', $job->getId())
+        ));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            sprintf('Job "%s" is in status "processing", letting the job to finish.', $job->getId())
+        ));
+        self::assertEquals(0, $ret);
+        $process = Process::fromShellCommandline('docker ps --format "{{.ID}}"');
+        $process->mustRun();
+        $containers = explode("\n", $process->getOutput());
+        // all containers are preserved (no cleanup occurred)
+        self::assertCount(1, array_intersect($nonJobContainers, $containers));
+        self::assertCount(2, array_intersect($jobContainers, $containers));
         putenv('JOB_ID=');
     }
 

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -187,14 +187,13 @@ class CleanupCommandTest extends AbstractCommandTest
         $testHandler = new TestHandler();
         $logger->pushHandler($testHandler);
 
-        putenv('JOB_ID=<>!$@%#^$');
+        putenv('JOB_ID=111111111111');
         $commandTester = new CommandTester($command);
         $ret = $commandTester->execute([
             'command' => $command->getName(),
         ]);
 
-        self::assertTrue($testHandler->hasInfoThatContains('Terminating containers for job "<>!$@%#^$".'));
-        self::assertTrue($testHandler->hasInfoThatContains('Finished container cleanup for job "<>!$@%#^$".'));
+        self::assertTrue($testHandler->hasErrorThatContains('Failed to get job "111111111111" for cleanup:'));
         self::assertEquals(0, $ret);
     }
 

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -170,7 +170,7 @@ class CleanupCommandTest extends AbstractCommandTest
         $process->mustRun();
         $containers = explode("\n", $process->getOutput());
         // all containers are preserved (no cleanup occurred)
-        self::assertCount(1, array_intersect($nonJobContainers, $containers));
+        self::assertGreaterThan(1, array_intersect($nonJobContainers, $containers));
         self::assertCount(2, array_intersect($jobContainers, $containers));
         putenv('JOB_ID=');
     }

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -62,7 +62,7 @@ class RunCommandTest extends AbstractCommandTest
 
     public function testExecuteSuccess(): void
     {
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         $job = $jobFactory->createNewJob([
             'componentId' => 'keboola.runner-config-test',
             '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
@@ -166,7 +166,7 @@ class RunCommandTest extends AbstractCommandTest
             ]
         );
         $configurationId = $componentsApi->addConfiguration($configurationApi)['id'];
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         try {
             $job = $jobFactory->createNewJob([
                 'componentId' => 'keboola.runner-config-test',
@@ -243,7 +243,7 @@ class RunCommandTest extends AbstractCommandTest
     public function testExecuteUnEncryptedJobData(): void
     {
         $storageClientFactory = new JobFactory\StorageClientFactory((string) getenv('STORAGE_API_URL'));
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         $storageClient = $storageClientFactory->getClient((string) getenv('TEST_STORAGE_API_TOKEN'));
         $tokenInfo = $storageClient->verifytoken();
         // fabricate an erroneous job which contains unencrypted values
@@ -300,7 +300,7 @@ class RunCommandTest extends AbstractCommandTest
 
     public function testExecuteDoubleFailure(): void
     {
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         $job = $jobFactory->createNewJob([
             'componentId' => 'keboola.ex-http',
             '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
@@ -349,7 +349,7 @@ class RunCommandTest extends AbstractCommandTest
 
     public function testExecuteSkip(): void
     {
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         $job = $jobFactory->createNewJob([
             'componentId' => 'keboola.ex-http',
             '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
@@ -393,7 +393,7 @@ class RunCommandTest extends AbstractCommandTest
 
     public function testExecuteCustomBackendConfig(): void
     {
-        list($jobFactory, $client) = $this->getJobFactoryAndClient();
+        list('factory' => $jobFactory, 'client' => $client) = $this->getJobFactoryAndClient();
         $job = $jobFactory->createNewJob([
             'componentId' => 'keboola.runner-config-test',
             '#tokenString' => getenv('TEST_STORAGE_API_TOKEN'),


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2558
required for https://github.com/keboola/job-queue-daemon/pull/187

Podle https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination

preStop hook (neboli cleanup command se spustí), pokud má Kubernetes potřebu pod ukončit. Což se stane pokud job nastavil job na terminating, v takovém případě ukončení triggeruje démon (https://github.com/keboola/job-queue-daemon/blob/297081084a51acba3511f586138e03f1367750b6/src/Daemon/Operation/TerminateJobOperation.php#L52) - v tom případě se cleanupCommand provede (pokiluje containery komponent a nechá doběhnout obalový container runneru) nebo se to stane z vůle kubernetesu (restartování instance) - v tom případě se cleanuCommand neprovede a nechá containery doběhnout a kubernetes by měl čeka po terminationGracePeriodSeconds na dokončení jobu.

\+ drobnej refactoring testů, aby se tam pořád neopakovala inicializace job factory