### PR TITLE
PS-4008 Downgrade DataDog ext to 0.74.0 (last known working version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,9 @@ ARG APP_USER_NAME
 ARG APP_USER_UID
 ARG APP_USER_GID
 
-ENV DD_PHP_TRACER_VERSION=0.80.0
+ENV DD_PHP_TRACER_VERSION=0.74.0
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV APP_ENV prod
-
-WORKDIR /code
 
 RUN apt-get update -q \
     && apt-get install -y --no-install-recommends \
@@ -40,7 +38,7 @@ RUN wget https://download.docker.com/linux/debian/gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Datadog
-RUN curl -LOf "https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php" > /tmp/datadog-setup.php \
+RUN curl -Lf "https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php" > /tmp/datadog-setup.php \
  && php /tmp/datadog-setup.php --php-bin=all --enable-appsec --enable-profiling \
  && rm /tmp/datadog-setup.php
 
@@ -55,6 +53,7 @@ COPY ./docker/php.ini /usr/local/etc/php/php.ini
 RUN docker-php-ext-install pcntl zip \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
+WORKDIR /code
 COPY composer.* symfony.lock ./
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-9

Fix DD installation & downgrade to the last known working version (0.74.0). Ozkouseno na testingu (`dev-PS-4008.3`)