### PR TITLE
disable DD application security monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN wget https://download.docker.com/linux/debian/gpg \
 
 # Datadog
 RUN curl -Lf "https://github.com/DataDog/dd-trace-php/releases/download/${DD_PHP_TRACER_VERSION}/datadog-setup.php" > /tmp/datadog-setup.php \
- && php /tmp/datadog-setup.php --php-bin=all --enable-appsec --enable-profiling \
+ && php /tmp/datadog-setup.php --php-bin=all --enable-profiling \
  && rm /tmp/datadog-setup.php
 
 # create app user


### PR DESCRIPTION
podobne ako v https://github.com/keboola/job-queue-daemon/pull/363
Mame nejakym cargo cultom omylom zapnuty application security monitoring a nikto otom nevedel, dokym neprisla faktura na $700 za app sec monitoring uz druhy krat (prvykrat [tu](https://keboola.slack.com/archives/C03SRE77QEP/p1662972635515279)).
Touto upravou to na dobro vypinam aby sme sa tomu v buducnosti vyhli a zapli to len ked to vedome chceme a potrebujeme.