### PR TITLE
Add job result state to APM trace

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -286,6 +286,13 @@ class RunCommand extends Command
 
     private function postJobResult(string $jobId, string $status, JobResult $result, ?JobMetrics $metrics = null): void
     {
+        if (function_exists('\DDTrace\root_span')) {
+            $span = root_span();
+            if ($span) {
+                $span->meta['job.result'] = $status;
+            }
+        }
+
         try {
             $this->queueClient->postJobResult($jobId, $status, $result, $metrics);
         } catch (StateTerminalException $e) {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -290,6 +290,11 @@ class RunCommand extends Command
             $span = root_span();
             if ($span) {
                 $span->meta['job.result'] = $status;
+
+                if ($status === JobInterface::STATUS_ERROR) {
+                    $span->meta['error.msg'] = $result->getMessage();
+                    $span->meta['error.type'] = $result->getErrorType();
+                }
             }
         }
 


### PR DESCRIPTION
Probirali jsme s @Halama (a tusim i nekym dalsim) offline, ze by se nam hodilo v APM job runneru poznat, zda job failnul.

![screenshot-app datadoghq eu-2023 01 03-10_29_46](https://user-images.githubusercontent.com/271753/210331135-f79892a0-bff1-4906-b9f2-7fa272a877d0.png)

Dva commity tady predstavuji dve varianty reseni:
* prvni jen prida do tagu `job.result: error`
* druhy tag navic prida `error.message: ...`, coz zaroven zpusobi, ze se cely `console` trace oznaci jako error a v seznamu je to pak videt jako failnute

S tou druhou variantou je asi jen trochu na zvazeni, jeslti to chceme, protoze to tak trochu lze - ten job runner jako taky nefailnul, problem je v komponente uvnitr. Na druhou stranu to vyrazne usnadnuje hledani failnutych jobu.