### PR TITLE
GCP-273 Standard pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,297 +6,106 @@ trigger:
       - '*'
   tags:
     include:
-      - '*'
+      - 'dev-*'
 
-variables:
-  acrRepositoryMain: 'keboola.azurecr.io'
-  acrRepositoryPes: 'keboolapes.azurecr.io'
-  garRepository: us-central1-docker.pkg.dev/keboola-prod-artifacts
-  garRepositoryProjectId: keboola-prod-artifacts
-  imageName: 'job-runner'
-  tag: $(Build.BuildId)
-  productionTag: production-$(Build.SourceVersion)
+pool:
+  vmImage: ubuntu-latest
 
 stages:
-  - stage: prepare
-    displayName: Prepare & Test
-    pool:
-      name: 'Default'
+  - stage: build
+    displayName: Build
+    dependsOn: []
     jobs:
-      - job: test
-        displayName: 'Test'
+      - job: build
+        displayName: Build Docker Images
         steps:
-          - task: Docker@2
-            displayName: Test ACR login
-            inputs:
-              command: login
-              containerRegistry: 'Keboola PS Test ACR'
+          - script: docker build --target=base --tag keboola/job-runner .
+            displayName: Build Docker images
 
-          - script: ./provisioning/ci/pipelines-scripts/terraform-install.sh
-            displayName: 'Install Terraform'
+          - template: azure-pipelines/steps/store-docker-artifact.yml
 
-          - script: ./provisioning/ci/pipelines-scripts/terraform-init.sh
-            displayName: Init Terraform
-            env:
-              AWS_ACCESS_KEY_ID: $(TERRAFORM_AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(TERRAFORM_AWS_SECRET_ACCESS_KEY)
-
-          - script: ./provisioning/ci/update-env.sh -v -e .env -a aws
-            displayName: Configure ENV
-            env:
-              AWS_ACCESS_KEY_ID: $(TERRAFORM_AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(TERRAFORM_AWS_SECRET_ACCESS_KEY)
-
-          - script: |
-              set -e
-              docker-compose down
-              docker-compose build
-              docker-compose pull internal-api
-            displayName: 'Build Tests'
-
-          - script: |
-              set -e
-              docker-compose up -d internal-api
-              docker-compose logs internal-api
-
-              docker-compose run ci
-            displayName: 'Run Tests'
-            env:
-              TEST_STORAGE_API_TOKEN: $(TEST_STORAGE_API_TOKEN)
-              TEST_STORAGE_API_TOKEN_MASTER: $(TEST_STORAGE_API_TOKEN_MASTER)
-
-          - script: |
-              set -Eeuo pipefail
-
-              docker image save keboola/$(imageName):latest -o $(Build.ArtifactStagingDirectory)/build-image.tar
-            displayName: 'Save image'
-
-          - publish: $(Build.ArtifactStagingDirectory)
-            artifact: docker-images
-            displayName: 'Publish artifacts'
-
-  # Push test image to test ACR
-  - stage: deploy_test
-    displayName: Deploy Test
+  - stage: tests
+    displayName: Tests
+    dependsOn: build
     pool:
-      vmImage: ubuntu-latest
+      name: Default # run on custom worker, tests needs Docker socket
     jobs:
-      - job: deploy
-        displayName: 'Deploy'
-        steps:
-          - download: current
-            artifact: docker-images
-            displayName: 'Download artifacts'
+      - template: azure-pipelines/jobs/run-tests.yml
+        parameters:
+          displayName: Run Tests
+          envName: aws
+          secrets:
+            TEST_STORAGE_API_TOKEN: $(TEST_STORAGE_API_TOKEN)
+            TEST_STORAGE_API_TOKEN_MASTER: $(TEST_STORAGE_API_TOKEN_MASTER)
 
-          - script: |
-              set -Eeuo pipefail
-              docker load --input $(Pipeline.Workspace)/docker-images/build-image.tar
-
-              docker tag keboola/$(imageName):latest keboola/$(imageName):$(productionTag)
-              docker tag keboola/$(imageName):latest keboola/$(imageName):$(tag)
-
-              docker tag keboola/$(imageName):latest $(acrRepositoryPes)/$(imageName):$(productionTag)
-              docker tag keboola/$(imageName):latest $(acrRepositoryPes)/$(imageName):$(tag)
-              docker tag keboola/$(imageName):latest $(acrRepositoryPes)/$(imageName):latest
-            displayName: 'Load image'
-
-          # Push test image to test AWS ECR
-          - task: ECRPushImage@1
-            displayName: 'Push ECR [$(productionTag)]'
-            inputs:
-              regionName: 'eu-central-1'
-              imageSource: 'imagename'
-              sourceImageName: keboola/$(imageName)
-              sourceImageTag: $(tag)
-              repositoryName: 'keboola/$(imageName)'
-              pushTag: $(productionTag)
-              autoCreateRepository: true
-            env:
-              AWS_ACCESS_KEY_ID: $(TEST_AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(TEST_AWS_SECRET_ACCESS_KEY)
-
-          - task: ECRPushImage@1
-            displayName: 'Push ECR [$(tag)]'
-            inputs:
-              regionName: 'eu-central-1'
-              imageSource: 'imagename'
-              sourceImageName: keboola/$(imageName)
-              sourceImageTag: $(tag)
-              repositoryName: 'keboola/$(imageName)'
-              pushTag: $(productionTag)
-              autoCreateRepository: true
-            env:
-              AWS_ACCESS_KEY_ID: $(TEST_AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(TEST_AWS_SECRET_ACCESS_KEY)
-
-          - task: ECRPushImage@1
-            displayName: 'Push ECR latest'
-            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-            inputs:
-              regionName: 'eu-central-1'
-              imageSource: 'imagename'
-              sourceImageName: keboola/$(imageName)
-              sourceImageTag: 'latest'
-              repositoryName: 'keboola/$(imageName)'
-              pushTag: 'latest'
-              autoCreateRepository: true
-            env:
-              AWS_ACCESS_KEY_ID: $(TEST_AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(TEST_AWS_SECRET_ACCESS_KEY)
-
-          - task: Docker@2
-            displayName: 'Push ACR [$(productionTag), $(tag)]'
-            inputs:
-              command: push
-              containerRegistry: 'Keboola PS Test ACR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: $(imageName)
-              tags: |
-                $(productionTag)
-                $(tag)
-
-          - task: Docker@2
-            displayName: 'Push ACR [latest]'
-            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-            inputs:
-              command: push
-              containerRegistry: 'Keboola PS Test ACR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: $(imageName)
-              tags: |
-                latest
-
-  # Push image to production
-  - stage:
-    displayName: Deploy Production
-    dependsOn: prepare
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-    pool:
-      vmImage: ubuntu-latest
-    jobs:
-      - job: deploy
-        displayName: 'Deploy'
-        steps:
-          - download: current
-            artifact: docker-images
-            displayName: 'Download artifacts'
-
-          - script: |
-              set -Eeuo pipefail
-              docker load --input $(Pipeline.Workspace)/docker-images/build-image.tar
-              docker tag keboola/$(imageName):latest keboola/$(imageName):$(productionTag)
-              docker tag keboola/$(imageName):latest $(garRepository)/$(imageName)/$(imageName):$(productionTag)
-              docker tag keboola/$(imageName):latest $(acrRepositoryMain)/$(imageName):$(productionTag)
-            displayName: 'Load image'
-
-          - task: ECRPushImage@1
-            displayName: 'Push to ECR [$(productionTag)]'
-            inputs:
-              awsCredentials: 'Production - ECR Distribution'
-              regionName: 'us-east-1'
-              imageSource: 'imagename'
-              sourceImageName: keboola/$(imageName)
-              sourceImageTag: latest
-              repositoryName: 'keboola/$(imageName)'
-              pushTag: $(productionTag)
-
-          - task: Docker@2
-            displayName: 'Push to GAR [$(productionTag)]'
-            inputs:
-              command: push
-              containerRegistry: 'Keboola GAR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: '$(garRepositoryProjectId)/$(imageName)/$(imageName)'
-              tags: $(productionTag)
-
-          - task: Docker@2
-            displayName: 'Push to ACR $(productionTag)'
-            inputs:
-              command: push
-              containerRegistry: 'Keboola ACR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: $(imageName)
-              tags: |
-                $(productionTag)
-
-          - task: Docker@2
-            displayName: 'Push to Docker Hub $(productionTag)'
-            inputs:
-              command: push
-              containerRegistry: 'Docker Hub'
-              repository: keboola/$(imageName)
-              tags: |
-                $(productionTag)
-
-          - script: |
-              printf "%s" "$(productionTag)" > artifact
-            displayName: Create artifact
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: 'artifact'
-              artifact: 'keboola.job-runner.latest-build'
-
-
-  # Push image to production (dev-* tags)
-  - stage:
-    displayName: Deploy Production (dev-* tags)
-    dependsOn: prepare
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/dev-'))
-    pool:
-      vmImage: ubuntu-latest
+  # push to testing
+  - stage: publishImages_testing
+    displayName: Publish Testing Images
+    dependsOn: [build, tests]
     jobs:
       - job:
-        displayName: Publish Production Images (dev tag)
-        variables:
-          - name: dockerTag
-            value: ${{ replace(variables['Build.SourceBranch'],'refs/tags/','') }}
+        displayName: Publish Docker Images
         steps:
-          - download: current
-            artifact: docker-images
-            displayName: 'Download artifacts'
+          - template: azure-pipelines/steps/restore-docker-artifact.yml
+          - template: azure-pipelines/steps/push-docker-image.yml
+            parameters:
+              displayName: Testing
+              awsCredentials: Testing - ECR Distribution
+              awsRegionName: eu-central-1
+              acrRegistry: keboolapes.azurecr.io
+              sourceImage: keboola/job-runner
+              targetImage: job-runner
+              tags:
+                - build-$(Build.SourceVersion)
+                - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+                    - latest
 
-          - script: |
-              set -Eeuo pipefail
-              docker load --input $(Pipeline.Workspace)/docker-images/build-image.tar
-              docker tag keboola/$(imageName):latest keboola/$(imageName):$(dockerTag)
-              docker tag keboola/$(imageName):latest $(garRepository)/$(imageName)/$(imageName):$(dockerTag)
-              docker tag keboola/$(imageName):latest $(acrRepositoryMain)/$(imageName):$(dockerTag)
-            displayName: 'Load image'
+  # push to production (dev-* tags)
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/dev-') }}:
+      - stage: publishImages_production
+        displayName: Publish Production Images (dev tag)
+        dependsOn: [build, tests]
+        jobs:
+          - job:
+            displayName: Publish Docker Images
+            steps:
+              - template: azure-pipelines/steps/restore-docker-artifact.yml
+              - template: azure-pipelines/steps/push-docker-image.yml
+                parameters:
+                  displayName: Production
+                  awsCredentials: Production - ECR Distribution
+                  awsRegionName: us-east-1
+                  acrRegistry: keboola.azurecr.io
+                  garPushEnabled: True
+                  garRegistry: Keboola GAR
+                  garRepository: us-central1-docker.pkg.dev/keboola-prod-artifacts
+                  garRepositoryProjectId: keboola-prod-artifacts
+                  sourceImage: keboola/job-runner
+                  targetImage: job-runner
+                  tags:
+                    - ${{ replace(variables['Build.SourceBranch'],'refs/tags/','') }}
 
-          - task: ECRPushImage@1
-            displayName: 'Push to ECR [$(dockerTag)]'
-            inputs:
-              awsCredentials: 'Production - ECR Distribution'
-              regionName: 'us-east-1'
-              imageSource: 'imagename'
-              sourceImageName: keboola/$(imageName)
-              sourceImageTag: latest
-              repositoryName: 'keboola/$(imageName)'
-              pushTag: $(dockerTag)
-
-          - task: Docker@2
-            displayName: 'Push to GAR [$(dockerTag)]'
-            inputs:
-              command: push
-              containerRegistry: 'Keboola GAR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: '$(garRepositoryProjectId)/$(imageName)/$(imageName)'
-              tags: $(dockerTag)
-
-          - task: Docker@2
-            displayName: 'Push to ACR [$(dockerTag)]'
-            inputs:
-              command: push
-              containerRegistry: 'Keboola ACR'
-              dockerfile: '$(Build.SourcesDirectory)/Dockerfile'
-              repository: $(imageName)
-              tags: $(dockerTag)
-
-          - task: Docker@2
-            displayName: 'Push to Docker Hub [$(dockerTag)]'
-            inputs:
-              command: push
-              containerRegistry: 'Docker Hub'
-              repository: keboola/$(imageName)
-              tags: $(dockerTag)
+  # push to production (main branch)
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - stage: publishImages_production
+        displayName: Publish Production Images (main branch)
+        dependsOn: [build, tests]
+        jobs:
+          - job:
+            displayName: Publish Docker Images
+            steps:
+              - template: azure-pipelines/steps/restore-docker-artifact.yml
+              - template: azure-pipelines/steps/push-docker-image.yml
+                parameters:
+                  displayName: Production
+                  awsCredentials: Production - ECR Distribution
+                  awsRegionName: us-east-1
+                  acrRegistry: keboola.azurecr.io
+                  garPushEnabled: True
+                  garRegistry: Keboola GAR
+                  garRepository: us-central1-docker.pkg.dev/keboola-prod-artifacts
+                  garRepositoryProjectId: keboola-prod-artifacts
+                  sourceImage: keboola/job-runner
+                  targetImage: job-runner
+                  tags:
+                    - production-$(Build.SourceVersion)

--- a/azure-pipelines/jobs/run-tests.yml
+++ b/azure-pipelines/jobs/run-tests.yml
@@ -1,0 +1,76 @@
+parameters:
+  - name: name
+    type: string
+    default:
+
+  - name: displayName
+    type: string
+    default: Tests
+
+  - name: dependsOn
+    type: string
+    default:
+
+  - name: serviceName
+    type: string
+    default: ci
+
+  - name: testCommand
+    type: string
+    default: composer ci
+
+  - name: variables
+    type: object
+    default: {}
+
+  - name: secrets
+    type: object
+    default: {}
+
+  - name: dockerArtifactName
+    type: string
+    default: docker-images
+
+  - name: dockerArtifactFile
+    type: string
+    default: docker-images.tar
+
+  - name: envName
+    type: string
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    dependsOn: ${{ parameters.dependsOn }}
+    variables: ${{ parameters.variables }}
+    steps:
+      - template: ../steps/restore-docker-artifact.yml
+
+      - task: Docker@2
+        displayName: Test ACR login
+        inputs:
+          command: login
+          containerRegistry: 'Keboola PS Test ACR'
+
+      - script: ./provisioning/ci/pipelines-scripts/terraform-install.sh
+        displayName: Install Terraform
+
+      - script: ./provisioning/ci/pipelines-scripts/terraform-init.sh
+        displayName: Init Terraform
+        env:
+          AWS_ACCESS_KEY_ID: $(TERRAFORM_AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(TERRAFORM_AWS_SECRET_ACCESS_KEY)
+
+      - script: ./provisioning/ci/update-env.sh -v -e .env -a ${{ parameters.envName }}
+        displayName: Configure ENV
+        env:
+          AWS_ACCESS_KEY_ID: $(TERRAFORM_AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(TERRAFORM_AWS_SECRET_ACCESS_KEY)
+
+      - script: docker-compose run --rm ${{ parameters.serviceName }} ${{ parameters.testCommand }}
+        displayName: Run tests
+        env: ${{ parameters.secrets }}
+
+      - script: docker-compose logs
+        displayName: Show logs
+        condition: failed()

--- a/azure-pipelines/steps/push-acr.yml
+++ b/azure-pipelines/steps/push-acr.yml
@@ -1,0 +1,36 @@
+parameters:
+  - name: displayName
+    type: string
+
+  - name: condition
+    type: string
+    default: True
+
+  - name: acrRegistry
+    type: string
+
+  - name: sourceImage
+    type: string
+
+  - name: targetImage
+    type: string
+
+  - name: tags
+    type: object
+    default: [latest]
+
+steps:
+- ${{ each tag in parameters.tags }}:
+  - script: docker tag ${{ parameters.sourceImage }} ${{ parameters.acrRegistry }}/${{ parameters.targetImage }}:${{ tag }}
+    displayName: ${{ parameters.displayName }} - Tag ${{ tag }}
+
+- task: Docker@2
+  displayName: ${{ parameters.displayName }} - Login
+  inputs:
+    command: login
+    containerRegistry: ${{ parameters.acrRegistry }}
+  condition: and(succeeded(), gt(${{ length(parameters.tags) }}, 0))
+
+- script: docker push -a ${{ parameters.acrRegistry }}/${{ parameters.targetImage }}
+  displayName: ${{ parameters.displayName }} - Push
+  condition: and(succeeded(), gt(${{ length(parameters.tags) }}, 0))

--- a/azure-pipelines/steps/push-docker-image.yml
+++ b/azure-pipelines/steps/push-docker-image.yml
@@ -1,0 +1,73 @@
+parameters:
+  - name: displayName
+    type: string
+
+  - name: condition
+    type: string
+    default: True
+
+  - name: awsCredentials
+    type: string
+
+  - name: awsRegionName
+    type: string
+
+  - name: acrRegistry
+    type: string
+
+  - name: garPushEnabled
+    type: string
+    default: False
+
+  - name: garRegistry
+    type: string
+    default: ""
+
+  - name: garRepository
+    type: string
+    default: ""
+
+  - name: garRepositoryProjectId
+    type: string
+    default: ""
+
+  - name: sourceImage
+    type: string
+
+  - name: targetImage
+    type: string
+
+  - name: tags
+    type: object
+
+steps:
+- template: push-ecr.yml
+  parameters:
+    displayName: Push ECR - ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}
+    awsCredentials: ${{ parameters.awsCredentials }}
+    awsRegionName: ${{ parameters.awsRegionName }}
+    sourceImage: ${{ parameters.sourceImage }}
+    targetImage: keboola/${{ parameters.targetImage }}
+    tags: ${{ parameters.tags }}
+
+- template: push-gar.yml
+  parameters:
+    displayName: Push GAR - ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}
+    garPushEnabled: ${{ parameters.garPushEnabled }}
+    garRegistry: ${{ parameters.garRegistry }}
+    garRepository: ${{ parameters.garRepository }}
+    garRepositoryProjectId: ${{ parameters.garRepositoryProjectId }}
+    sourceImage: ${{ parameters.sourceImage }}
+    targetImage: ${{ parameters.targetImage }}
+    tags: ${{ parameters.tags }}
+
+- template: push-acr.yml
+  parameters:
+    displayName: Push ACR - ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}
+    acrRegistry: ${{ parameters.acrRegistry }}
+    sourceImage: ${{ parameters.sourceImage }}
+    targetImage: ${{ parameters.targetImage }}
+    tags: ${{ parameters.tags }}

--- a/azure-pipelines/steps/push-ecr.yml
+++ b/azure-pipelines/steps/push-ecr.yml
@@ -1,0 +1,38 @@
+parameters:
+  - name: displayName
+    type: string
+
+  - name: condition
+    type: string
+    default: True
+
+  - name: awsCredentials
+    type: string
+    default: aws-testing
+
+  - name: awsRegionName
+    type: string
+    default: eu-central-1
+
+  - name: sourceImage
+    type: string
+
+  - name: targetImage
+    type: string
+
+  - name: tags
+    type: object
+    default: [latest]
+
+steps:
+- ${{ each tag in parameters.tags }}:
+  - task: ECRPushImage@1
+    displayName: ${{ parameters.displayName }} - ${{ tag }}
+    inputs:
+      awsCredentials: ${{ parameters.awsCredentials }}
+      regionName: ${{ parameters.awsRegionName }}
+      imageSource: imagename
+      sourceImageName: ${{ parameters.sourceImage }}
+      repositoryName: ${{ parameters.targetImage }}
+      pushTag: ${{ tag }}
+    condition: ${{ parameters.condition }}

--- a/azure-pipelines/steps/push-gar.yml
+++ b/azure-pipelines/steps/push-gar.yml
@@ -1,0 +1,46 @@
+parameters:
+  - name: displayName
+    type: string
+
+  - name: condition
+    type: string
+    default: True
+
+  - name: garPushEnabled
+    type: string
+    default: False
+
+  - name: garRegistry
+    type: string
+
+  - name: garRepository
+    type: string
+
+  - name: garRepositoryProjectId
+    type: string
+
+  - name: sourceImage
+    type: string
+
+  - name: targetImage
+    type: string
+
+  - name: tags
+    type: object
+    default: [latest]
+
+steps:
+- ${{ each tag in parameters.tags }}:
+    - script: docker tag ${{ parameters.sourceImage }}:latest ${{ parameters.garRepository }}/${{ parameters.targetImage }}/${{ parameters.targetImage }}:${{ tag }}
+      displayName: ${{ parameters.displayName }} - Build tag ${{ tag }}
+      condition: and(succeeded(), eq('${{ parameters.condition }}', 'True'), eq('${{ parameters.garPushEnabled }}', 'True'))
+
+- ${{ each tag in parameters.tags }}:
+  - task: Docker@2
+    displayName: ${{ parameters.displayName }} - Push tag ${{ tag }}
+    inputs:
+      command: push
+      containerRegistry: ${{ parameters.garRegistry }}
+      repository: ${{ parameters.garRepositoryProjectId }}/${{ parameters.targetImage }}/${{ parameters.targetImage }}
+      tags: ${{ tag }}
+    condition: and(succeeded(), eq('${{ parameters.condition }}', 'True'), eq('${{ parameters.garPushEnabled }}', 'True'))

--- a/azure-pipelines/steps/restore-directory-artifact.yml
+++ b/azure-pipelines/steps/restore-directory-artifact.yml
@@ -1,0 +1,11 @@
+parameters:
+  - name: name
+    type: string
+
+steps:
+  - download: current
+    artifact: ${{ parameters.name }}
+    displayName: Download ${{ parameters.name }} artifact
+
+  - script: tar xvf "$(Pipeline.Workspace)/${{ parameters.name }}/${{ parameters.name }}.tar"
+    displayName: Restore ${{ parameters.name }} artifact

--- a/azure-pipelines/steps/restore-docker-artifact.yml
+++ b/azure-pipelines/steps/restore-docker-artifact.yml
@@ -1,0 +1,17 @@
+parameters:
+  - name: name
+    type: string
+    default: docker-images
+
+  - name: dockerArtifactFile
+    type: string
+    default: docker-images.tar
+
+
+steps:
+  - download: current
+    artifact: ${{ parameters.name }}
+    displayName: Download artifacts
+
+  - script: docker load --input $(Pipeline.Workspace)/${{ parameters.name }}/${{ parameters.dockerArtifactFile }}
+    displayName: Load images

--- a/azure-pipelines/steps/store-directory-artifact.yml
+++ b/azure-pipelines/steps/store-directory-artifact.yml
@@ -1,0 +1,14 @@
+parameters:
+  - name: name
+    type: string
+
+  - name: path
+    type: string
+
+steps:
+  - script: tar cvf "$(Build.ArtifactStagingDirectory)/${{ parameters.name }}.tar" "${{ parameters.path }}"
+    displayName: Export ${{ parameters.name }} artifact
+
+  - publish: "$(Build.ArtifactStagingDirectory)/${{ parameters.name }}.tar"
+    artifact: ${{ parameters.name }}
+    displayName: Publish ${{ parameters.name }} artifact

--- a/azure-pipelines/steps/store-docker-artifact.yml
+++ b/azure-pipelines/steps/store-docker-artifact.yml
@@ -1,0 +1,16 @@
+parameters:
+  - name: imagesFilter
+    type: string
+    default: keboola/*
+
+  - name: name
+    type: string
+    default: docker-images
+
+steps:
+  - script: docker image save $(docker image ls --filter 'reference=${{ parameters.imagesFilter }}' --format '{{.Repository}}:latest') -o "$(Build.ArtifactStagingDirectory)/${{ parameters.name }}.tar"
+    displayName: Export ${{ parameters.name }} artifact
+
+  - publish: "$(Build.ArtifactStagingDirectory)/${{ parameters.name }}.tar"
+    artifact: ${{ parameters.name }}
+    displayName: Publish ${{ parameters.name }} artifact

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       APP_ENV: test
       TEST_STORAGE_API_TOKEN:
       TEST_STORAGE_API_TOKEN_MASTER:
-
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/:/tmp/

--- a/provisioning/ci/aws_encryption.tf
+++ b/provisioning/ci/aws_encryption.tf
@@ -8,7 +8,7 @@ resource "aws_iam_user_policy" "job_runner_kms_access" {
   name_prefix = "kms_access_"
 
   policy = jsonencode({
-    "Version"   = "2012-10-17",
+    "Version" = "2012-10-17",
     "Statement" = [
       {
         "Sid"    = "UseKMS",

--- a/provisioning/ci/gcp.tf
+++ b/provisioning/ci/gcp.tf
@@ -1,6 +1,6 @@
 locals {
   gcp_project = "kbc-ci-platform-services"
-  gcp_region = "us-central1"
+  gcp_region  = "us-central1"
 }
 
 provider "google" {

--- a/provisioning/ci/main.tf
+++ b/provisioning/ci/main.tf
@@ -25,11 +25,11 @@ terraform {
 }
 
 locals {
-  app_name = "job-runner"
+  app_name         = "job-runner"
   app_display_name = "Job Runner"
 }
 
 variable "name_prefix" {
-  type = string
+  type    = string
   default = "ci"
 }

--- a/provisioning/ci/prepare-aws-resources.sh
+++ b/provisioning/ci/prepare-aws-resources.sh
@@ -15,11 +15,13 @@ REPO_NAME=job-runner
 
 TERRAFORM_BACKEND_STACK_PREFIX=ci-${REPO_NAME}
 TERRAFORM_BACKEND_STACK_NAME="${TERRAFORM_BACKEND_STACK_PREFIX}-terraform"
+ECR_REPO_NAME=keboola/${REPO_NAME}
 OIDC_PROVIDE_ARN=arn:aws:iam::480319613404:oidc-provider/token.actions.githubusercontent.com
 
 aws cloudformation deploy --stack-name "${TERRAFORM_BACKEND_STACK_NAME}" \
   --parameter-overrides \
     "BackendPrefix=${TERRAFORM_BACKEND_STACK_PREFIX}" \
+    "EcrRepoName=${ECR_REPO_NAME}" \
     "OIDCProviderArn=${OIDC_PROVIDE_ARN}" \
     "GitHubOrganization=keboola" \
     "GitHubRepositoryName=${REPO_NAME}" \

--- a/provisioning/ci/resources/aws.yaml
+++ b/provisioning/ci/resources/aws.yaml
@@ -4,6 +4,9 @@ Parameters:
   BackendPrefix:
     Type: String
     Description: Prefix for all Terraform Backend resources
+  EcrRepoName:
+    Type: String
+    Description: Name of the repository
   OIDCProviderArn:
     Type: String
     Description: OIDC Provider ARN
@@ -55,6 +58,12 @@ Resources:
           Value:
             Fn::Sub: "${BackendPrefix}-terraform-table"
 
+  EcrRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      ImageTagMutability: MUTABLE
+      RepositoryName: !Ref EcrRepoName
+
   AzurePipelinesUser:
     Type: AWS::IAM::User
     Properties:
@@ -82,6 +91,29 @@ Resources:
                   Fn::GetAtt:
                     - TerraformRemoteStateLockDynamoDBTable
                     - Arn
+        - PolicyName: AllowEcrPush
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AllowPush
+                Effect: Allow
+                Action:
+                  - ecr:BatchGetImage
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:CompleteLayerUpload
+                  - ecr:DescribeImages
+                  - ecr:DescribeRepositories
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:InitiateLayerUpload
+                  - ecr:ListImages
+                  - ecr:PutImage
+                  - ecr:UploadLayerPart
+                Resource: !GetAtt EcrRepository.Arn
+              - Sid: GetAuthorizationToken
+                Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: "*"
 
   GithubActionsRole:
     Type: AWS::IAM::Role

--- a/provisioning/local/aws_encryption.tf
+++ b/provisioning/local/aws_encryption.tf
@@ -8,7 +8,7 @@ resource "aws_iam_user_policy" "job_runner_kms_access" {
   name_prefix = "kms_access_"
 
   policy = jsonencode({
-    "Version"   = "2012-10-17",
+    "Version" = "2012-10-17",
     "Statement" = [
       {
         "Sid"    = "UseKMS",

--- a/provisioning/local/gcp.tf
+++ b/provisioning/local/gcp.tf
@@ -1,6 +1,6 @@
 locals {
   gcp_project = "kbc-dev-platform-services"
-  gcp_region = "europe-west1"
+  gcp_region  = "europe-west1"
 }
 
 provider "google" {

--- a/tests/Command/RunCommandTerminateTest.php
+++ b/tests/Command/RunCommandTerminateTest.php
@@ -111,7 +111,7 @@ class RunCommandTerminateTest extends AbstractCommandTest
             actually create containers, we'd still have to create the containers not belonging to the job, so let's
             do them all here.
         */
-        $commandText = 'docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=300 ' .
+        $commandText = 'sudo docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=300 ' .
             '--label com.keboola.docker-runner.jobId=%s waisbrot/wait';
         $tmpProcess = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
         $tmpProcess->setTimeout(600); // to pull the image if necessary
@@ -121,14 +121,14 @@ class RunCommandTerminateTest extends AbstractCommandTest
         $tmpProcess = Process::fromShellCommandline(sprintf($commandText, 4321));
         $tmpProcess->mustRun();
         $tmpProcess = Process::fromShellCommandline(sprintf(
-            'docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"',
+            'sudo docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"',
             $job->getId()
         ));
         $tmpProcess->mustRun();
         $containerIdsToRemove = explode("\n", trim($tmpProcess->getOutput()));
 
         $tmpProcess = Process::fromShellCommandline(
-            'docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=4321"'
+            'sudo docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=4321"'
         );
         $tmpProcess->mustRun();
         $containerIdsToKeep = explode("\n", trim($tmpProcess->getOutput()));
@@ -178,7 +178,7 @@ class RunCommandTerminateTest extends AbstractCommandTest
         );
         self::assertEquals(0, $mainProcess->getExitCode());
 
-        $tmpProcess = Process::fromShellCommandline('docker ps --format "{{.ID}}"');
+        $tmpProcess = Process::fromShellCommandline('sudo docker ps --format "{{.ID}}"');
         $tmpProcess->mustRun();
         $containers = explode("\n", $tmpProcess->getOutput());
         self::assertContains($containerIdsToKeep[0], $containers);
@@ -225,7 +225,7 @@ class RunCommandTerminateTest extends AbstractCommandTest
         ]);
         $job = $client->createJob($job);
 
-        $commandText = 'docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=300 ' .
+        $commandText = 'sudo docker run -d -e TARGETS=localhost:12345 -e TIMEOUT=300 ' .
             '--label com.keboola.docker-runner.jobId=%s waisbrot/wait';
         $tmpProcess = Process::fromShellCommandline(sprintf($commandText, $job->getId()));
         $tmpProcess->setTimeout(600); // to pull the image if necessary
@@ -234,13 +234,14 @@ class RunCommandTerminateTest extends AbstractCommandTest
         $tmpProcess->mustRun();
         $tmpProcess = Process::fromShellCommandline(sprintf($commandText, 4321));
         $tmpProcess->mustRun();
-        $tmpProcess = Process::fromShellCommandline(
-            sprintf('docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"', $job->getId())
-        );
+        $tmpProcess = Process::fromShellCommandline(sprintf(
+            'sudo docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=%s"',
+            $job->getId(),
+        ));
         $tmpProcess->mustRun();
         $jobContainers = explode("\n", trim($tmpProcess->getOutput()));
         $tmpProcess = Process::fromShellCommandline(
-            'docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=4321"'
+            'sudo docker ps --format "{{.ID}}" --filter "label=com.keboola.docker-runner.jobId=4321"'
         );
         $tmpProcess->mustRun();
         $nonJobContainers = explode("\n", trim($tmpProcess->getOutput()));
@@ -293,7 +294,7 @@ class RunCommandTerminateTest extends AbstractCommandTest
         );
         self::assertEquals(0, $mainProcess->getExitCode());
 
-        $tmpProcess = Process::fromShellCommandline('docker ps --format "{{.ID}}"');
+        $tmpProcess = Process::fromShellCommandline('sudo docker ps --format "{{.ID}}"');
         $tmpProcess->mustRun();
         $containers = explode("\n", $tmpProcess->getOutput());
         // all containers are preserved (no cleanup occurred)


### PR DESCRIPTION
https://keboola.atlassian.net/browse/GCP-273

NENI NUTNE, JE TO JEN CLEANUP

Pipeline se tu chovala trochu jinak, nez jsme zvykli jinde - napr. pushovala images otagovane jako `production-{hash}` pri buildu z branch :sweat_smile: Nastesti to nevadilo, protoze runner neni standardni appka a je extra releasovanej pres pipeline daemona, ale chvili jse mi ale tocila hlava kolem.