### PR TITLE
Put back publish of build artifact after succesfull `main` build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,3 +109,10 @@ stages:
                   targetImage: job-runner
                   tags:
                     - production-$(Build.SourceVersion)
+
+              - script: printf "%s" "$(productionTag)" > artifact
+                displayName: Create artifact
+              - task: PublishPipelineArtifact@1
+                inputs:
+                  targetPath: artifact
+                  artifact: keboola.job-runner.latest-build


### PR DESCRIPTION
Kdyz jsem cistil pipeline, prehlidl jsem, ze na konci buildu `main` branch publishujeme artifact, na ktery je pak vazany CI daemona, tekry ted kvuli tomu failuje.

https://dev.azure.com/keboola-dev/job-queue-daemon/_build/results?buildId=38595&view=logs&j=7d5b28db-2126-5d2e-52cc-bfb5d57393a5&t=818b8543-007a-589d-5de0-a617faa20b41