### PR TITLE
GCP-293 Configurable temp dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git
-var
-vendor
+azure-pipelines/
+provisioning/
+var/
+vendor/
 bin/.phpunit

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,11 @@ RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
 
 COPY . .
 RUN composer install $COMPOSER_FLAGS \
-    && chown -R "${APP_USER_NAME}:${APP_USER_NAME}" var/
+ && chown -R "${APP_USER_NAME}:${APP_USER_NAME}" var/ \
+ && chown "${APP_USER_NAME}:${APP_USER_NAME}" vendor/infection/extension-installer/src/GeneratedExtensionsConfig.php
 
 USER $APP_USER_NAME
-
+ENTRYPOINT ["/code/bin/app-entrypoint.sh"]
 CMD ["php", "/code/bin/console", "app:run"]
 
 

--- a/bin/app-entrypoint.sh
+++ b/bin/app-entrypoint.sh
@@ -11,5 +11,11 @@ echo "=== Preparing application for ${APP_ENV} environment"
 # finish install scripts
 composer run post-install-cmd
 
+DATA_VOLUME_HOST_PATH="${DATA_VOLUME_HOST_PATH:-}"
+if [ ! -z "${DATA_VOLUME_HOST_PATH}" ]; then
+  echo "Setting TMPDIR to \"${DATA_VOLUME_HOST_PATH}\""
+  export TMPDIR="${DATA_VOLUME_HOST_PATH}"
+fi
+
 echo "=== Setup done, starting application"
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
https://keboola.atlassian.net/browse/GCP-293
Job Queue Daemon PR: https://github.com/keboola/job-queue-daemon/pull/451

Konfigurovatelny directory pro data jobu. Cesta pro data dir jobu se pripravujeme pres `Temp` class, ktera pouziva `sys_get_temp_dir` (https://github.com/keboola/php-temp/blob/master/src/Temp.php#L55). To se da pretizit nastavenim `TMPDIR` env a tim padem neni potreba zadna uprava kodu, jen tahle konfigurace.

Jako side-effect, kteyr je ale vlastne ku prospechu, PHP bude vsechny docasny files davat na pod `DATA_VOLUME_HOST_PATH`.

Bohuzel, zmena `TMPDIR` se za behu PHP nepropise a musi se teda nastavit jeste pred starte, takze se soucasnou strukturou testu nejde zmenu otestovat (musel by byt test, ktery by poustel komplet novy PHP process). V daemonovi ale bude funkcni test na pusteni jobu se zmenenou `DATA_VOLUME_HOST_PATH`.

Abysme mohli cestu nastavovat pres ENV, je potreba konfiguraci poresit v entrypointu. Ten (`bin/app-entrypoint.sh`) tu sice uz histociky byl, ale vubec se nepouzival :slightly_smiling_face: (v `Dockerfile` vubec nebyl `ENCTRYPOINT`, jen `CMD`). Nechal jsem ho tak, jak byl (stejne jako mame normalne na appkach), ale ma to nejake dopady:
* start jobu je o cca 2 sekundy pomalejsi
* v outputu `job-runner` Podu (tim padem v logach v Datadogu, ale ne v eventech jobu) je navic output toho entrypoint scriptu
![image](https://github.com/keboola/job-runner/assets/271753/35bfa251-ee2e-4da0-a0eb-7d8503d87431)

To zpomaleni startu bych nevidel jako problem. Co se tyce toho vystupu entrypoint skriptu, mame to takle defaultne, protoze u appek to dava smysl videt. Runner ale neni appka, tak by se to pripadne dalo poladit. Co si o tom myslite? Jedine co musi urcite zustat je ten radek s `Setting TMPDIR to "/var/tmp"` - hlidam ho v testech v damonovi a pokud budou nejake problemy s mountovanim v produkci, bude IMHO k nezaplaceni pro debug.