### PR TITLE
Remove unnecessary stuff from entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,7 @@ RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
 
 COPY . .
 RUN composer install $COMPOSER_FLAGS \
- && chown -R "${APP_USER_NAME}:${APP_USER_NAME}" var/ \
- && chown "${APP_USER_NAME}:${APP_USER_NAME}" vendor/infection/extension-installer/src/GeneratedExtensionsConfig.php
+ && chown -R "${APP_USER_NAME}:${APP_USER_NAME}" var/
 
 USER $APP_USER_NAME
 ENTRYPOINT ["/code/bin/app-entrypoint.sh"]

--- a/bin/app-entrypoint.sh
+++ b/bin/app-entrypoint.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-if [ -z "${APP_ENV}" ]; then
-  echo "Environment variable APP_ENV must be set"
-  exit 1
-fi
-
-echo "=== Preparing application for ${APP_ENV} environment"
-
-# finish install scripts
-composer run post-install-cmd
-
 DATA_VOLUME_HOST_PATH="${DATA_VOLUME_HOST_PATH:-}"
 if [ ! -z "${DATA_VOLUME_HOST_PATH}" ]; then
   echo "Setting TMPDIR to \"${DATA_VOLUME_HOST_PATH}\""
   export TMPDIR="${DATA_VOLUME_HOST_PATH}"
 fi
 
-echo "=== Setup done, starting application"
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
Pri implementaci konfigurovatelneho TMP_DIR (https://github.com/keboola/job-runner/pull/245) se do `job-runner` pridal standardni entrypoint, kteyr pouzivame nomrlane v Symfony appkach. Runner je ale takova specialitka a ty standardni veci tu nejsou potreba. Naopak to lehce brzi start joby (1-2 sekundy) a hazi zbytecne traces do DD https://keboolaglobal.slack.com/archives/C054JTK9KJ8/p1699351363434939.

Otestoval jsem na AZ testingu, je joby se dal nomralne pusti.