### PR TITLE
Increase job-queue-internal-api retries

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -85,6 +85,9 @@ services:
             $internalQueueApiUrl: '%env(JOB_QUEUE_URL)%'
             $internalQueueToken: ~
             $storageApiToken: '%env(STORAGE_API_TOKEN)%'
+            $options:
+                userAgent: 'QueueRunner'
+                backoffMaxTries: 20
 
     Keboola\StorageApiBranch\Factory\ClientOptions:
         $url: '%env(STORAGE_API_URL)%'


### PR DESCRIPTION
FIXES https://keboola.atlassian.net/browse/PST-1548

Otestoval jsem na testingu na testingu.
- Predtim padlo po ocekavaných 18 min https://keboola.atlassian.net/browse/ST-1435?focusedCommentId=96567
- Ted vydrzelo 40 min odstavku. https://app.datadoghq.eu/apm/trace/366189945382193522?colorBy=service&env=dev-keboola-aws-eu-west-1&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=17915474614636001793&spanViewType=metadata&timeHint=1710761931775.7039&view=spans
 
<img width="1570" alt="image" src="https://github.com/keboola/job-runner/assets/903531/6697ad1b-3502-4b33-8545-d0e267a43681">

