### PR TITLE
Fix early signal handling, when runner is not initialized yet

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -47,7 +47,7 @@ use function DDTrace\root_span;
 #[AsCommand(name: 'app:run')]
 class RunCommand extends Command
 {
-    private Runner $runner;
+    private ?Runner $runner = null;
 
     public function __construct(
         private readonly Logger $logger,
@@ -101,9 +101,12 @@ class RunCommand extends Command
             $this->terminateContainer($containerId);
         }
 
-        $this->logger->info(sprintf('Clearing up workspaces for job "%s".', $this->jobId));
-        $this->runner->cleanup();
-        $this->logger->info(sprintf('Finished cleanup for job "%s".', $this->jobId));
+        if ($this->runner !== null) {
+            $this->logger->info(sprintf('Clearing up workspaces for job "%s".', $this->jobId));
+            $this->runner->cleanup();
+            $this->logger->info(sprintf('Finished cleanup for job "%s".', $this->jobId));
+        }
+
         exit;
     }
 


### PR DESCRIPTION
Oprava failujicich testu daemona https://dev.azure.com/keboola-dev/job-queue-daemon/_build/results?buildId=44538&view=logs&j=1be0cbee-eb0a-5a47-7da4-730df842813d&t=ebebd7a8-7f10-570f-1d95-84ab7f0466b2. Signal handler se vola driv, nez se stihne runner nainicializovat.

Zkousel jsem napsat test, ale nenasle jsem cestu, jak ho udelat spolehlivy:
* signal handler se vola asynchronne, takze test by byl dost time sensitive (zkousel jsem tam vrazit nejake sleep apod., ale nenasel jsme zadnou spolehlive fungujici konfiguraci)
* kdyz signal handler skonci nejakym fatal errorem, exit code je stejne `0`, takze nejde z venku jednoduse poznat, jestli je problem spravne osetreny (slo by asi objeit kontrolou output, kam se zapisuji logy)