### PR TITLE
update dockerbundle  - ignore HTTP 404 from staging provider cleanup

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1689,7 +1689,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/docker-bundle",
-                "reference": "9e3086cd639429ce4a03d60e9a10f33d3595e679"
+                "reference": "ec5fb96f0537348469b2170f839f2c03929db92d"
             },
             "require": {
                 "ext-json": "*",
@@ -1780,7 +1780,7 @@
                 }
             ],
             "description": "Component for running Docker images in KBC",
-            "time": "2024-12-10T11:22:04+00:00"
+            "time": "2024-12-18T16:10:10+00:00"
         },
         {
             "name": "keboola/gelf-server",


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PST-323 Part2

Nasazeni https://github.com/keboola/docker-bundle/pull/775

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [[PST-2357](https://keboola.atlassian.net/browse/PST-2357)] under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918)


---



[PST-2357]: https://keboola.atlassian.net/browse/PST-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ