### PR TITLE
update keboola/output-mapping - delete_where in OM functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "keboola/input-mapping": "^18.9",
         "keboola/job-queue-internal-api-php-client": "^23.4",
         "keboola/object-encryptor": "^2.8",
-        "keboola/output-mapping": "^24.39",
+        "keboola/output-mapping": "^24.39.1",
         "keboola/slicer": "^2.0.1",
         "keboola/storage-api-client": "^15.2",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "keboola/input-mapping": "^18.9",
         "keboola/job-queue-internal-api-php-client": "^23.4",
         "keboola/object-encryptor": "^2.8",
-        "keboola/output-mapping": "^24.38",
+        "keboola/output-mapping": "^24.39",
         "keboola/slicer": "^2.0.1",
         "keboola/storage-api-client": "^15.2",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdcaae544955b954bf1fd3c87ceedd1c",
+    "content-hash": "bb5e09112ac5bb2f156344d3d70d3c94",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2145,16 +2145,16 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "24.38.0",
+            "version": "24.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "3d8e5a38951b752d68f6cadfe95e5a62b607aae2"
+                "reference": "fa68f2fb8829e95d0cb53a4fbbfbe449524669f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/3d8e5a38951b752d68f6cadfe95e5a62b607aae2",
-                "reference": "3d8e5a38951b752d68f6cadfe95e5a62b607aae2",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/fa68f2fb8829e95d0cb53a4fbbfbe449524669f8",
+                "reference": "fa68f2fb8829e95d0cb53a4fbbfbe449524669f8",
                 "shasum": ""
             },
             "require": {
@@ -2211,9 +2211,9 @@
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
             "support": {
-                "source": "https://github.com/keboola/output-mapping/tree/24.38.0"
+                "source": "https://github.com/keboola/output-mapping/tree/24.39.0"
             },
-            "time": "2025-01-23T11:52:27+00:00"
+            "time": "2025-01-30T07:50:40+00:00"
         },
         {
             "name": "keboola/permission-checker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb5e09112ac5bb2f156344d3d70d3c94",
+    "content-hash": "2e18407d66e486d49e3ee26da6762cc6",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2145,16 +2145,16 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "24.39.0",
+            "version": "24.39.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "fa68f2fb8829e95d0cb53a4fbbfbe449524669f8"
+                "reference": "7dff679c9885d80c4f56454c66cbae787ce2aee3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/fa68f2fb8829e95d0cb53a4fbbfbe449524669f8",
-                "reference": "fa68f2fb8829e95d0cb53a4fbbfbe449524669f8",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/7dff679c9885d80c4f56454c66cbae787ce2aee3",
+                "reference": "7dff679c9885d80c4f56454c66cbae787ce2aee3",
                 "shasum": ""
             },
             "require": {
@@ -2211,9 +2211,9 @@
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
             "support": {
-                "source": "https://github.com/keboola/output-mapping/tree/24.39.0"
+                "source": "https://github.com/keboola/output-mapping/tree/24.39.1"
             },
-            "time": "2025-01-30T07:50:40+00:00"
+            "time": "2025-01-30T12:43:24+00:00"
         },
         {
             "name": "keboola/permission-checker",


### PR DESCRIPTION
Jira: [PST-2398](https://keboola.atlassian.net/browse/PST-2398)

Before asking for review, check the following:

- [x] ~~For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [PST-XXX] under the [no-DIND epic]~~(https://keboola.atlassian.net/browse/PST-918) - není potřeba


---

Aktualizace Output Mappingu - implementovaná logika `delete_where` u tables

[PST-2398]: https://keboola.atlassian.net/browse/PST-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ