### PR TITLE
feat: Push also `production-*` tag to testing registries

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,7 @@ stages:
                 - build-$(Build.SourceVersion)
                 - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
                     - latest
+                    - production-$(Build.SourceVersion)
 
   # push to production (dev-* tags)
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/dev-') }}:


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2074
Je potreba pro https://github.com/keboola/job-queue-daemon/pull/579

Pushovani `production-*` tagu do testing registry, pokud se buildi `main` branch.

Ve finale to umozni, ze
* `local` i `ci` testy daemona muzou jet proti stejnymu ECR
* `ci` daemona muze referencovat posledni produkcni tag runneru (protoze ten ma format `production-*`), zatim co `local` pouziva `latest`