### PR TITLE
fix: Fix DebugModeTest with updated Docker

### DIFF
--- a/tests/Functional/DebugModeTest.php
+++ b/tests/Functional/DebugModeTest.php
@@ -216,7 +216,7 @@ class DebugModeTest extends BaseFunctionalTest
             ],
         ];
         $expectedJobResult = [
-            'message' => 'Intentional error',
+            'message' => "Intentional error\nexit status 1",
             'configVersion' => '',
             'images' => [],
         ];


### PR DESCRIPTION
V ramci releasu https://github.com/keboola/job-runner/pull/353 se rozbilo CI. V noci z 19.2. na 20.2.2025 vysel Docker 28, ktery do outputu pri erroru nove vypisuje status kod.