### PR TITLE
Update PR template, to create also no-dind PR (not just task)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Jira: PST-XXX
 
 Before asking for review, check the following:
 
-- [ ] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [PST-XXX] under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918)
+- [ ] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding PR.
 
 
 ---


### PR DESCRIPTION
`no-dind` uz bezi v produkci, takze jakekoliv zmeny uz musime releasovat rovnou i tam, ne je jen zaplanovat "az nekdy".
