### PR TITLE
PAT-1529: Apply fallback for components with undefined definition.name

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1658,7 +1658,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/docker-bundle",
-                "reference": "c03d0a8a2bea0b43ac2bfb7231b6ffc78ee6f324"
+                "reference": "6fdf8048e539d9913b4723e4bec043d8ccccd918"
             },
             "require": {
                 "ext-json": "*",
@@ -1750,7 +1750,7 @@
                 }
             ],
             "description": "Component for running Docker images in KBC",
-            "time": "2026-02-24T14:25:19+00:00"
+            "time": "2026-03-04T19:08:22+00:00"
         },
         {
             "name": "keboola/gelf-server",


### PR DESCRIPTION
https://linear.app/keboola/issue/PAT-1529/job-runner-compose-image-uri-with-fallback

## Description
Follow-up to https://github.com/keboola/docker-bundle/pull/801 — updates `keboola/dockerbundle` to implement the undefined `definition.name` fallback from https://github.com/keboola/docker-bundle/pull/801.

## Release Notes
- **Justification**
   We need to mitigate the strict behavior introduced in https://github.com/keboola/docker-bundle/pull/800: if `definition.name` is undefined, we use [the old-way URI resolving](https://github.com/keboola/docker-bundle/pull/801/changes#diff-e89e260b9ddaae933bee616c3f6fb320ca0cb8a1b15338c7954bf7851a13d47aR37) and log a warning.

- **Plans for Customer Communication**
   None.

- **Impact Analysis**
   No impact is expected unless implemented incorrectly.

- **Deployment Plan**
   Merge.

- **Rollback Plan**
   Revert this PR.

- **Post-Release Support Plan**
   Monitor job-runner in DD.