### PR TITLE
chore(deps): AJDA-2715 bump keboola/input-mapping to 22.5.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1813,16 +1813,16 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "22.4.0",
+            "version": "22.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "b9a925dd871f12e295347122f82540b3204d9d2a"
+                "reference": "314fde7c2399043ed477e97e47d54f007ad7c971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/b9a925dd871f12e295347122f82540b3204d9d2a",
-                "reference": "b9a925dd871f12e295347122f82540b3204d9d2a",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/314fde7c2399043ed477e97e47d54f007ad7c971",
+                "reference": "314fde7c2399043ed477e97e47d54f007ad7c971",
                 "shasum": ""
             },
             "require": {
@@ -1879,9 +1879,9 @@
             ],
             "description": "Input mapping library for downloading tables and files from Keboola Storage API with support for CSV and Parquet formats",
             "support": {
-                "source": "https://github.com/keboola/input-mapping/tree/22.4.0"
+                "source": "https://github.com/keboola/input-mapping/tree/22.5.0"
             },
-            "time": "2026-02-02T13:15:18+00:00"
+            "time": "2026-06-01T15:42:48+00:00"
         },
         {
             "name": "keboola/job-queue-artifacts",


### PR DESCRIPTION
Jira: [AJDA-2715](https://linear.app/keboola/issue/AJDA-2715/acept-loadtype-option-in-im)

Before asking for review, check the following:

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding PR. https://github.com/keboola/job-queue/pull/712
---

In this PR I have...

## Description

Bumped `keboola/input-mapping` from 22.4.0 to 22.5.0, which adds support for the `loadType` option in input mapping table configurations (following the naming used in the Storage API load-data reference). This pulls the new library capability into job-runner so jobs can use the option end-to-end. The `composer.json` constraint (`^22.3`) already permits this version, so only `composer.lock` changes.

## Justification

See the linked issue. Part of the BigQuery parity / CLONE function work — accepting the `loadType` option in input mapping.

## Plans for Customer Communication

None.

## Impact Analysis

Dependency bump only; behavior is additive (a new optional `loadType` option). No change to existing job behavior when the option is not used. No single-tenant-specific impact.

## Deployment Plan

Standard CI/CD.

## Rollback Plan

Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan

None.
