### PR TITLE
chore(deps): AJDA-2714 bump input-mapping to 23.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "keboola/api-error-control": "^4.2",
         "keboola/configuration-variables-resolver": "^5.3",
         "keboola/dockerbundle": "dev-main",
-        "keboola/input-mapping": "23.1.0",
+        "keboola/input-mapping": "^23.1",
         "keboola/job-queue-internal-api-php-client": "^25.5",
         "keboola/job-queue-job-configuration": "^3.6",
         "keboola/object-encryptor": "^2.14",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "keboola/api-error-control": "^4.2",
         "keboola/configuration-variables-resolver": "^5.3",
         "keboola/dockerbundle": "dev-main",
-        "keboola/input-mapping": "^23.0",
+        "keboola/input-mapping": "23.1.0",
         "keboola/job-queue-internal-api-php-client": "^25.5",
         "keboola/job-queue-job-configuration": "^3.6",
         "keboola/object-encryptor": "^2.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80a8fe77e9c1162296fef4585a828ef5",
+    "content-hash": "4b70a022285c1389d8f347c49de19d99",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "daa7762dd97bf6ca361205d6ceec1d35",
+    "content-hash": "80a8fe77e9c1162296fef4585a828ef5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1818,16 +1818,16 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "23.0.0",
+            "version": "23.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "fffa84a075d7e49002101367ee182cee1ea6b010"
+                "reference": "8dd283dad4f43b2e37024a9ccce1b993be16cd45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/fffa84a075d7e49002101367ee182cee1ea6b010",
-                "reference": "fffa84a075d7e49002101367ee182cee1ea6b010",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/8dd283dad4f43b2e37024a9ccce1b993be16cd45",
+                "reference": "8dd283dad4f43b2e37024a9ccce1b993be16cd45",
                 "shasum": ""
             },
             "require": {
@@ -1884,9 +1884,9 @@
             ],
             "description": "Input mapping library for downloading tables and files from Keboola Storage API with support for CSV and Parquet formats",
             "support": {
-                "source": "https://github.com/keboola/input-mapping/tree/23.0.0"
+                "source": "https://github.com/keboola/input-mapping/tree/23.1.0"
             },
-            "time": "2026-06-18T08:50:23+00:00"
+            "time": "2026-06-29T14:24:19+00:00"
         },
         {
             "name": "keboola/job-queue-artifacts",


### PR DESCRIPTION
Jira: https://linear.app/keboola/issue/AJDA-2714/input-mapping-read-description-primarily-from-table-definition

Depends on / brings in: https://github.com/keboola/platform-libraries/pull/533

Testovací joby https://connection.canary-orion.keboola.dev/admin/projects/503/queue/503992

IM Component: https://github.com/keboola/job-queue/pull/723

## Description

Bumps `keboola/input-mapping` to the released `23.1.0`, which makes the input mapping read a table's description primarily from the table definition (see keboola/platform-libraries#533). No application code changes — dependency bump only.

The branch previously pinned the dev branch (`dev-odin/AJDA-2714`) for canary verification; now that the library is released, the constraint is switched to the released version.

## Justification

See the linked Linear issue.

## Plans for Customer Communication

None.

## Impact Analysis

Dependency-only change scoped to the input-mapping library. Affects how the table description is sourced during input mapping (now primarily from the table definition). No feature flag.

## Deployment Plan

Standard CI/CD.

## Rollback Plan

Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan

None.

---

In this PR I have...

- Bumped `keboola/input-mapping` to the released `23.1.0`.
